### PR TITLE
Fixed annoying expedition 2 smoke bug

### DIFF
--- a/AHKanColle.ahk
+++ b/AHKanColle.ahk
@@ -289,7 +289,9 @@ Resupply(r)
 	GuiControl,, NB, Resupplying expedition %r%
     if r = 2
 	{
-        ClickS(2Rx,234Ry)
+		pc := []
+		pc := [EX2PC]
+		WaitForPixelColor(2Rx,234Ry,pc,2Rx,234Ry)
 	}
     else if r = 3
 	{

--- a/Constants/PixelColor.ahk
+++ b/Constants/PixelColor.ahk
@@ -25,3 +25,4 @@ NBPC := 0x408 ;Night Battle
 CSPC := 0x162629 ;Continue Screen
 CCPC := 0xcc5852 ;Critical
 IBPC := 0x3a87b3 ;In Battle
+EX2PC := 0x23A0A1 ; Expedition 2 highlighted 


### PR DESCRIPTION
Sometimes a damaged unit from fleet 1 would block you from clicking expedition 2 for a period of time. Function will now check if expedition 2 is clicked or not