### PR TITLE
Fix smoke bug

### DIFF
--- a/AHKanColle.ahk
+++ b/AHKanColle.ahk
@@ -289,7 +289,9 @@ Resupply(r)
 	GuiControl,, NB, Resupplying expedition %r%
     if r = 2
 	{
-        ClickS(2Rx,234Ry)
+		pc := []
+		pc := [EX2PC]
+		WaitForPixelColor(2Rx,234Ry,pc,2Rx,234Ry)
 	}
     else if r = 3
 	{

--- a/AHKanColle.ahk
+++ b/AHKanColle.ahk
@@ -1,4 +1,4 @@
-﻿;AHKanColle v1.61121
+﻿;AHKanColle v1.61124
 
 if not A_IsAdmin
 {

--- a/Constants/PixelColor.ahk
+++ b/Constants/PixelColor.ahk
@@ -1,4 +1,4 @@
-﻿;Pixel Color Constants v1.51230
+﻿;Pixel Color Constants v1.61124
 
 HPC := 0x4acacd ;Home
 HEPC := 0x42b6b8 ;Home + Exped

--- a/Constants/PixelColor.ahk
+++ b/Constants/PixelColor.ahk
@@ -25,3 +25,4 @@ NBPC := 0x408 ;Night Battle
 CSPC := 0x162629 ;Continue Screen
 CCPC := 0xcc5852 ;Critical
 IBPC := 0x3a87b3 ;In Battle
+EX2PC := 0x23A0A1 ; Expedition 2 highlighted 


### PR DESCRIPTION
Fixed bug with resupplying second fleet when main fleet had smoke effects blocking the fleet selection. Thanks to @diceman112 for this fix.